### PR TITLE
Typo in quick start & home.md

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -46,11 +46,11 @@ This project aims to have a platform for evaluating and testing complex behavior
 
 * Loading a simulated environment for different scenarios where you can evaluate complex robots behaviors.
 * Generating datasets to train your models to be tested later.
-* Evaluate the performance of your models comparing them against a other models.
+* Evaluate the performance of your models by comparing them against other models.
 * Change the scenarios/models (called brains) on the go.
 * Live view of sensor readings.
 
-The algorithms that command the robots are called **brains**, and there is where the neural logic (behaviors) is at.
+The algorithms that command the robots are called **brains**, and that is where the neural logic (behaviors) is at.
 
 <img src="https://jderobot.github.io/assets/images/projects/neural_behavior/autonomous.jpeg" alt="config" style="zoom:50%;" />
 

--- a/_pages/quick_start/quick_start.md
+++ b/_pages/quick_start/quick_start.md
@@ -84,7 +84,7 @@ First of all you need to install Behavior Studio. If you haven't completed that 
 
 We additionally have some pretrained brains that you can use in Behavior Studio to illustrate how it works. Find them in the [brains zoo](/quick_start/brains_zoo/).
 
-If you'd like to train your own brain, we provide you the [datasets](/quick_start/datasets).
+If you'd like to train your own brain, we provide you with the [datasets](/quick_start/datasets).
 
 To run the application with GUI (Graphic User Interface) just run:
 


### PR DESCRIPTION
Typos in the documentation of quick_start (quick_start.md) & in home.md file in the gh-pages branch  (#153 ) . Merging request to solve it.