### PR TITLE
Added details about using custom CARLA object file and setting its env variables

### DIFF
--- a/_pages/install/install.md
+++ b/_pages/install/install.md
@@ -158,7 +158,9 @@ For installing CARLA and supporting this new simulator:
     export CARLA_ROOT=<PATH-TO-CARLA>/carla_simulator/
     export PYTHONPATH=$PYTHONPATH:$CARLA_ROOT/PythonAPI/carla
     export PYTHONPATH=$PYTHONPATH:$CARLA_ROOT/PythonAPI/carla/dist/carla-0.9.13-py3.7-linux-x86_64.egg   
+    export OBJECT_PATH=<PATH-TO-BEHAVIOR-METRICS>/behavior_metrics/configs/CARLA_launch_files/CARLA_object_files/parked_car_objects.json
 ```
+Note:$OBJECT_PATH is a sample CARLA objects json file containing objects to be spawned in the CARLA simulator. You can use your own json file by setting $OBJECT_PATH. More details about this are added in [Quick Start guide!](../quick_start/)\
 5. Test that everything is correctly set up running the example configuration file:
 ```bash
   python3 driver_carla.py -c configs/default_carla.yml -g

--- a/_pages/install/install.md
+++ b/_pages/install/install.md
@@ -160,7 +160,8 @@ For installing CARLA and supporting this new simulator:
     export PYTHONPATH=$PYTHONPATH:$CARLA_ROOT/PythonAPI/carla/dist/carla-0.9.13-py3.7-linux-x86_64.egg   
     export OBJECT_PATH=<PATH-TO-BEHAVIOR-METRICS>/behavior_metrics/configs/CARLA_launch_files/CARLA_object_files/parked_car_objects.json
 ```
-Note:$OBJECT_PATH is a sample CARLA objects json file containing objects to be spawned in the CARLA simulator. You can use your own json file by setting $OBJECT_PATH. More details about this are added in [Quick Start guide!](../quick_start/)\
+Note: `$OBJECT_PATH` is a sample CARLA objects json file containing objects to be spawned in the CARLA simulator. You can use your own json file by setting $OBJECT_PATH. More details about this are added in [Quick Start guide](../quick_start/)
+
 5. Test that everything is correctly set up running the example configuration file:
 ```bash
   python3 driver_carla.py -c configs/default_carla.yml -g

--- a/_pages/quick_start/quick_start.md
+++ b/_pages/quick_start/quick_start.md
@@ -421,3 +421,31 @@ As you type down the name of the frame, you will see how the name in the top-lef
 Once you have chosen the frame name (this is important for later), you have to chose the data type the frame will show, from one of the checkboxes below the name textbox. After that, you will only have to click the **Confirm** button and the sensor will show its data.
 
 {% include gallery id="gallery17" caption="" %}
+
+
+### Launching different objects in CARLA
+
+By default, while running ```python3 driver_carla.py -c configs/default_carla.yml -g``` , CARLA allows to spawn an ego vehicle along with its sensors. The default object file called here can be found in ```$(find carla_spawn_objects)/config/objects.json```.
+
+However, we can spawn different objects in the simulation by changing the object file. 
+
+To spawn, For Eg: an additional car (here an Audi), as an obstacle in CARLA Town, we can add the following in the object file at relevant hierarchy after the ego vehicle object:
+
+```json
+{
+    "type": "vehicle",
+    "id": "vehicle.audi.a2",
+}
+```
+A sample CARLA object file for this can be found [here](https://github.com/JdeRobot/BehaviorMetrics/blob/noetic-devel/behavior_metrics/configs/CARLA_launch_files/CARLA_object_files/parked_car_objects.json).
+
+The new object file env variable can be set as below:
+```bash
+export OBJECT_PATH=<PATH-TO-CARLA-OBJECT-FILE>
+```
+
+Now, replace the value of ```objects_definition_file``` args in the corresponding CARLA launch file with ```'$(env OBJECT_PATH)'```
+
+Sample launch file for this can be found [here](https://github.com/JdeRobot/BehaviorMetrics/blob/noetic-devel/behavior_metrics/configs/CARLA_launch_files/town_01_anticlockwise.launch)
+
+Now, pass this launch file to the CARLA configuration file ```default_carla.yml``` (under the **World** parameter) and run the driver as usual by ```python3 driver_carla.py -c configs/default_carla.yml -g```.


### PR DESCRIPTION
Fix https://github.com/JdeRobot/BehaviorMetrics/issues/608. Details added in **install** and **Quick Start** pages regarding using custom CARLA object files and setting its env variable OBJECT_PATH