### PR TITLE
Fixed broken links of homepage and included citation text

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -14,7 +14,7 @@ feature_row:
     alt: "Quick start CARLA examples"
     title: "Quick start CARLA examples"
     excerpt: "Load, run, get results and compare an example robot brain in CARLA"
-    url: "/quick_start/"
+    url: "/carla/quick_start/"
     btn_class: "btn--primary"
     btn_label: "Quick start CARLA examples"
 
@@ -43,7 +43,7 @@ gallery1:
 
 {% include feature_row %}
 
-**We are always open for new contributions from outside developers. If you want to contribute to this project, please visit the [CONTRIBUTING guide](/documentation/contributing/)**
+**We are always open for new contributions from outside developers. If you want to contribute to this project, please visit the [CONTRIBUTING guide](/BehaviorMetrics/documentation/contributing/)**
 
 This software tool provides evaluation capabilities for autonomous driving solutions using simulation. 
 We provide a series of quantitative metrics for the evaluation of autonomous driving solutions with support for two simulators, [CARLA](https://carla.org/) (main supported simulator) and [gazebo](https://gazebosim.org/home) (partial support).
@@ -68,10 +68,27 @@ For more information about the installation, go to this [link](/install/).
 
 ### Examples
 
-* [CARLA example](/carla/quick_start/)
-* [Gazebo example](/gazebo/quick_start/)
+* [CARLA example](/BehaviorMetrics/carla/quick_start/)
+* [Gazebo example](/BehaviorMetrics/gazebo/quick_start/)
 
 <img src="https://jderobot.github.io/assets/images/projects/neural_behavior/autonomous.jpeg" alt="config" />
 
+### Citation
+If you find our repo useful, please cite us as
+```bibtex
+@article{PANIEGO2024101702,
+title = {Behavior metrics: An open-source assessment tool for autonomous driving tasks},
+journal = {SoftwareX},
+volume = {26},
+pages = {101702},
+year = {2024},
+issn = {2352-7110},
+doi = {https://doi.org/10.1016/j.softx.2024.101702},
+url = {https://www.sciencedirect.com/science/article/pii/S2352711024000736},
+author = {Sergio Paniego and Roberto Calvo-Palomino and JoséMaría Cañas},
+keywords = {Evaluation tool, Autonomous driving, Imitation learning},
+abstract = {The development and validation of autonomous driving solutions require testing broadly in simulation. Addressing this requirement, we present Behavior Metrics (BM) for the quantitative and qualitative assessment and comparison of solutions for the main autonomous driving tasks. This software provides two evaluation pipelines, one with a graphical user interface used for qualitative assessment and the other headless for massive and unattended tests and benchmarks. It generates a series of quantitative metrics complementary to the simulator’s, including fine-grained metrics for each particular driving task (lane following, driving in traffic, route navigation, etc.). It provides a deeper and broader understanding of the solutions’ performance and allows their comparison and improvement. It uses and supports state-of-the-art open software such as the reference CARLA simulator, the ROS robotics middleware, PyTorch, and TensorFlow deep learning frameworks. BehaviorMetrics is available open-source for the community.}
+}
+```
 
 You can see the project status in the [GitHub repository here](https://github.com/JdeRobot/BehaviorMetrics).


### PR DESCRIPTION
This pull request addresses issues #679 and #680 .

I have added the citation text in a new section after examples.

I have fixed the intext links by adding "/BehaviorMetrics/" before the links. 

I have also fixed [Quick start CARLA examples](https://jderobot.github.io/BehaviorMetrics/carla/quick_start/)'s link by adding "/carla/" before "quick_start". 