### PR TITLE
chore(gh-pages): correct incorrect links on deployment pages

### DIFF
--- a/_pages/carla/quick_start.md
+++ b/_pages/carla/quick_start.md
@@ -93,11 +93,11 @@ gallery17:
 
 # Running an example
 
-First, you need to install Behavior Metrics. If you haven't completed that step, please go to the [installation section](BehaviorMetrics/install/).
+First, you need to install Behavior Metrics. If you haven't completed that step, please go to the [installation section](/install/).
 
-We additionally have some pretrained models that you can use in Behavior Metrics to illustrate how it works. Find them in the [model zoo](BehaviorMetrics/carla/model_zoo/).
+We additionally have some pretrained models that you can use in Behavior Metrics to illustrate how it works. Find them in the [model zoo](/carla/model_zoo/).
 
-If you'd like to train your own imitation learning based model, we provide you with a [dataset](BehaviorMetrics/carla/datasets/).
+If you'd like to train your own imitation learning based model, we provide you with a [dataset](/carla/datasets/).
 
 We provide examples for the follow-lane task using CARLA:
 


### PR DESCRIPTION
I found that the previous commit did not fix the earlier issue; my mistake. I re-checked and tested it locally; this is the new commit. @sergiopaniego 