### PR TITLE
Fix broken links in Quick start CARLA and other pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,8 +21,8 @@ title_separator          : "-"
 subtitle                 : "Autonomous driving solutions comparison tool"
 name                     : "JdeRobot"
 description              : "Programming Robot Intelligence"
-url                      : https://github.com/JdeRobot/BehaviorMetrics
-baseurl                  : # the subpath of your site, e.g. "/blog"
+url                      : https://jderobot.github.io
+baseurl                  : "/BehaviorMetrics"
 repository               : JdeRobot/BehaviorMetrics
 teaser                   : # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 logo                     : /assets/images/peloto.png

--- a/_pages/carla/quick_start.md
+++ b/_pages/carla/quick_start.md
@@ -93,11 +93,11 @@ gallery17:
 
 # Running an example
 
-First, you need to install Behavior Metrics. If you haven't completed that step, please go to the [installation section](/install/).
+First, you need to install Behavior Metrics. If you haven't completed that step, please go to the [installation section]({{ site.baseurl }}/install/).
 
-We additionally have some pretrained models that you can use in Behavior Metrics to illustrate how it works. Find them in the [model zoo](/carla/model_zoo/).
+We additionally have some pretrained models that you can use in Behavior Metrics to illustrate how it works. Find them in the [model zoo]({{ site.baseurl }}/carla/model_zoo/).
 
-If you'd like to train your own imitation learning based model, we provide you with a [dataset](/carla/datasets/).
+If you'd like to train your own imitation learning based model, we provide you with a [dataset]({{ site.baseurl }}/carla/datasets/).
 
 We provide examples for the follow-lane task using CARLA:
 

--- a/_pages/carla/tutorial.md
+++ b/_pages/carla/tutorial.md
@@ -24,7 +24,7 @@ In this tutorial, you will use Behavior Metrics to extract evaluation metrics us
 
 ## Prerequisites
 
-First of all, make sure you have Behavior Metrics installed, following the [installation section](/install/). You can try running the *brain_f1_explicit* that is already included on Behavior Metrics brains folder. This brain is capable of finishing every circuit available for the project.
+First of all, make sure you have Behavior Metrics installed, following the [installation section]({{ site.baseurl }}/install/). You can try running the *brain_f1_explicit* that is already included on Behavior Metrics brains folder. This brain is capable of finishing every circuit available for the project.
 
 ## Brain Class
 

--- a/_pages/gazebo/tutorial.md
+++ b/_pages/gazebo/tutorial.md
@@ -24,7 +24,7 @@ In this tutorial, you will train your first follow line brain for the F1 that ca
 
 ## Prerequisites
 
-First of all, make sure you have Behavior Metrics installed, following the [installation section](/install/). You can try running the *brain_f1_explicit* that is already included on Behavior Metrics brains folder. This brain is capable of finishing every circuit available for the project.
+First of all, make sure you have Behavior Metrics installed, following the [installation section]({{ site.baseurl }}/install/). You can try running the *brain_f1_explicit* that is already included on Behavior Metrics brains folder. This brain is capable of finishing every circuit available for the project.
 
 ## Brain Class
 

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -43,7 +43,7 @@ gallery1:
 
 {% include feature_row %}
 
-**We are always open for new contributions from outside developers. If you want to contribute to this project, please visit the [CONTRIBUTING guide](/BehaviorMetrics/documentation/contributing/)**
+**We are always open for new contributions from outside developers. If you want to contribute to this project, please visit the [CONTRIBUTING guide]({{ site.baseurl }}/documentation/contributing/)**
 
 This software tool provides evaluation capabilities for autonomous driving solutions using simulation. 
 We provide a series of quantitative metrics for the evaluation of autonomous driving solutions with support for two simulators, [CARLA](https://carla.org/) (main supported simulator) and [gazebo](https://gazebosim.org/home) (partial support).
@@ -64,12 +64,12 @@ The first one is intended for testing one brain+model at a time and debugging it
 
 ### Installation
 
-For more information about the installation, go to this [link](/install/). 
+For more information about the installation, go to this [link]({{ site.baseurl }}/install/). 
 
 ### Examples
 
-* [CARLA example](/BehaviorMetrics/carla/quick_start/)
-* [Gazebo example](/BehaviorMetrics/gazebo/quick_start/)
+* [CARLA example]({{ site.baseurl }}/carla/quick_start/)
+* [Gazebo example]({{ site.baseurl }}/gazebo/quick_start/)
 
 <img src="https://jderobot.github.io/assets/images/projects/neural_behavior/autonomous.jpeg" alt="config" />
 


### PR DESCRIPTION
## Summary

- Set correct `url` and `baseurl` in `_config.yml` for GitHub Pages deployment at `https://jderobot.github.io/BehaviorMetrics/`
- Update all hardcoded internal links in page content to use `{{ site.baseurl }}` so they resolve correctly under the `/BehaviorMetrics` subpath
- Fixes broken links in: Quick start CARLA (`_pages/carla/quick_start.md`), CARLA tutorial, Gazebo tutorial, and the home page

The root cause was that `baseurl` was not set in `_config.yml`, so all internal links (Installation, Model Zoo, Datasets, etc.) resolved to `https://jderobot.github.io/install/` instead of `https://jderobot.github.io/BehaviorMetrics/install/`.

Navigation sidebar links and gallery image paths are automatically handled by the minimal-mistakes theme's `relative_url` filter, so they work correctly once `baseurl` is set. Only the raw markdown links in page content needed manual `{{ site.baseurl }}` prefixing.

### Files changed

| File | Change |
|------|--------|
| `_config.yml` | Set `url: https://jderobot.github.io` and `baseurl: "/BehaviorMetrics"` |
| `_pages/carla/quick_start.md` | Fix 3 broken links (installation, model zoo, dataset) |
| `_pages/carla/tutorial.md` | Fix 1 broken link (installation) |
| `_pages/gazebo/tutorial.md` | Fix 1 broken link (installation) |
| `_pages/home.md` | Fix 4 links (contributing, installation, CARLA example, Gazebo example) |

## Test plan

- [ ] Verify links on the deployed GitHub Pages site resolve correctly
- [ ] Check that navigation sidebar links work
- [ ] Check that gallery images load properly

Fixes #724